### PR TITLE
Use supplied credentials based on given environment variables.

### DIFF
--- a/.run/com.google.cloud.solutions.autotokenize.pipeline.DlpInspectionPipeline.run.xml
+++ b/.run/com.google.cloud.solutions.autotokenize.pipeline.DlpInspectionPipeline.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="com.google.cloud.solutions.autotokenize.pipeline.DlpInspectionPipeline" type="Application" factoryName="Application" nameIsGenerated="true">
+  <configuration default="false" name="DlpInspectionPipeline" type="Application" factoryName="Application" nameIsGenerated="true">
     <envs>
       <env name="DATA_CATALOG_ENTRY_GROUP_ID" value="some_dev_entrygroup_id" />
       <env name="DLP_RUNNER_SERVICE_ACCOUNT_NAME" value="auto-dlp-runner" />

--- a/.run/com.google.cloud.solutions.autotokenize.pipeline.DlpInspectionPipeline.run.xml
+++ b/.run/com.google.cloud.solutions.autotokenize.pipeline.DlpInspectionPipeline.run.xml
@@ -1,0 +1,31 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="com.google.cloud.solutions.autotokenize.pipeline.DlpInspectionPipeline" type="Application" factoryName="Application" nameIsGenerated="true">
+    <envs>
+      <env name="DATA_CATALOG_ENTRY_GROUP_ID" value="some_dev_entrygroup_id" />
+      <env name="DLP_RUNNER_SERVICE_ACCOUNT_NAME" value="auto-dlp-runner" />
+      <env name="INSPECTION_TAG_TEMPLATE_ID" value="some_dev_inspectiontag" />
+      <env name="KMS_KEY_ID" value="dlptest-key" />
+      <env name="KMS_KEYRING_ID" value="dlptest-keyring" />
+      <env name="PROJECT_ID" value="dev-sirius" />
+      <env name="PROJECT_NUMBER" value="943886343370" />
+      <env name="REGION_ID" value="europe-north1" />
+      <env name="SECRET_MANAGER_KEY_NAME" value="autodlp_testkey_tinkey_wrapped" />
+      <env name="TEMP_GCS_BUCKET" value="ssb-test-dapla-auto-dlp" />
+      <env name="VPC_NAME" value="vpc-brunost" />
+      <env name="WRAPPED_KEY_FILE" value="wrapped_dlp_key.json" />
+      <env name="DLP_RUNNER_SERVICE_ACCOUNT_EMAIL" value="auto-dlp-runner@dev-sirius.iam.gserviceaccount.com" />
+    </envs>
+    <option name="MAIN_CLASS_NAME" value="com.google.cloud.solutions.autotokenize.pipeline.DlpInspectionPipeline" />
+    <module name="auto-data-tokenize.main" />
+    <option name="PROGRAM_PARAMETERS" value="--project=&quot;${PROJECT_ID}&quot; --region=&quot;${REGION_ID}&quot; --runner=&quot;DataflowRunner&quot; --serviceAccount=&quot;${DLP_RUNNER_SERVICE_ACCOUNT_EMAIL}&quot; --gcpTempLocation=&quot;gs://${TEMP_GCS_BUCKET}/temp&quot; --stagingLocation=&quot;gs://${TEMP_GCS_BUCKET}/staging&quot; --tempLocation=&quot;gs://${TEMP_GCS_BUCKET}/bqtemp&quot; --workerMachineType=&quot;n1-standard-1&quot; --subnetwork=&quot;${DATAFLOW_SUBNETWORK}&quot; --sampleSize=600 --sourceType=&quot;PARQUET&quot; --inputPattern=&quot;gs://${TEMP_GCS_BUCKET}/kilde/person_1200.parquet&quot; --reportLocation=&quot;gs://${TEMP_GCS_BUCKET}/dlpreport/01&quot;" />
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="com.google.cloud.solutions.autotokenize.pipeline.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/com.google.cloud.solutions.autotokenize.pipeline.DlpInspectionPipeline.run.xml
+++ b/.run/com.google.cloud.solutions.autotokenize.pipeline.DlpInspectionPipeline.run.xml
@@ -7,7 +7,7 @@
       <env name="KMS_KEY_ID" value="dlptest-key" />
       <env name="KMS_KEYRING_ID" value="dlptest-keyring" />
       <env name="PROJECT_ID" value="dev-sirius" />
-      <env name="PROJECT_NUMBER" value="943886343370" />
+      <env name="PROJECT_NUMBER" value="TODO" />
       <env name="REGION_ID" value="europe-north1" />
       <env name="SECRET_MANAGER_KEY_NAME" value="autodlp_testkey_tinkey_wrapped" />
       <env name="TEMP_GCS_BUCKET" value="ssb-test-dapla-auto-dlp" />

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ repositories {
 }
 
 def protoVersion = "3.20.1"
-def beamVersion = "2.38.0"
+def beamVersion = "2.39.0"
 def hadoopVersion = "3.3.1"
 def autoValueVersion = "1.8.2"
 def floggerVersion = "0.7.4"
@@ -66,6 +66,7 @@ dependencies {
     implementation "com.google.cloud:google-cloud-datacatalog:1.6.3"
     implementation "com.google.cloud:google-cloud-kms:2.4.0"
     implementation "com.google.cloud:google-cloud-secretmanager:2.0.7"
+    implementation "com.squareup.okhttp3:okhttp:4.9.3"
 
     // Google Tink for encryption
     implementation "com.google.crypto.tink:tink:1.6.1"
@@ -195,31 +196,6 @@ jacocoTestReport {
 }
 
 spotless {
-    java {
-        target "**/*.java"
-        targetExclude "third_party/**"
-        googleJavaFormat()
-        removeUnusedImports()
-        importOrder()
-        trimTrailingWhitespace()
-        endWithNewline()
-        licenseHeader "/*\n" +
-                " * Copyright \$YEAR Google LLC\n" +
-                " *\n" +
-                " * Licensed under the Apache License, Version 2.0 (the \"License\");\n" +
-                " * you may not use this file except in compliance with the License.\n" +
-                " * You may obtain a copy of the License at\n" +
-                " *\n" +
-                " *     https://www.apache.org/licenses/LICENSE-2.0\n" +
-                " *\n" +
-                " * Unless required by applicable law or agreed to in writing, software\n" +
-                " * distributed under the License is distributed on an \"AS IS\" BASIS,\n" +
-                " * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n" +
-                " * See the License for the specific language governing permissions and\n" +
-                " * limitations under the License.\n" +
-                " */\n" +
-                "\n"
-    }
 
     kotlin {
         target "**/*.kt"

--- a/src/main/java/com/google/cloud/solutions/autotokenize/auth/AccessTokenCredentialsFactory.java
+++ b/src/main/java/com/google/cloud/solutions/autotokenize/auth/AccessTokenCredentialsFactory.java
@@ -1,0 +1,57 @@
+package com.google.cloud.solutions.autotokenize.auth;
+
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.AccessToken;
+import com.google.common.flogger.GoogleLogger;
+import org.apache.beam.sdk.extensions.gcp.auth.CredentialFactory;
+import org.apache.beam.sdk.extensions.gcp.auth.GcpCredentialFactory;
+import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Date;
+
+/** Construct an oauth credential based on access tokens */
+public class AccessTokenCredentialsFactory implements CredentialFactory {
+
+    public static final String AUTH_PROVIDER_URL_KEY = "LOCAL_USER_PATH";
+    public static final String GCS_TOKEN_PROVIDER_KEY = "GCS_TOKEN_PROVIDER_KEY";
+    public static final String GCS_TOKEN_KEY = "GCS_TOKEN";
+    private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+    private final String quotaProjectId;
+
+    public static CredentialFactory fromOptions(PipelineOptions options) {
+        if (System.getenv().containsKey(AUTH_PROVIDER_URL_KEY) || System.getenv().containsKey(GCS_TOKEN_KEY)) {
+            return new AccessTokenCredentialsFactory(options.as(GcpOptions.class).getProject());
+        } else {
+            return GcpCredentialFactory.fromOptions(options);
+        }
+    }
+
+    public AccessTokenCredentialsFactory(String quotaProjectId) {
+        this.quotaProjectId = quotaProjectId;
+    }
+
+    @Override
+    public @Nullable Credentials getCredential() {
+        if (System.getenv().containsKey(AUTH_PROVIDER_URL_KEY)) {
+            logger.atInfo().log("Using credential provider url");
+            return new OAuth2CredentialsWithRefreshAndQuotaProjectId.Builder()
+                    .setQuotaProjectId(this.quotaProjectId)
+                    .setAccessToken(new AccessToken("", new Date(0L)))
+                    .setRefreshHandler(new JupyterHubAccessTokenProvider(System.getenv(AUTH_PROVIDER_URL_KEY),
+                            System.getenv(GCS_TOKEN_PROVIDER_KEY))).build();
+        } else if (System.getenv().containsKey(GCS_TOKEN_KEY)) {
+            logger.atInfo().log("Using credentials from env variable");
+            AccessToken accessToken = new AccessToken(System.getenv().get(GCS_TOKEN_KEY), new Date(System.currentTimeMillis()
+                    + 3600 * 1000));
+            return new OAuth2CredentialsWithRefreshAndQuotaProjectId.Builder()
+                    .setQuotaProjectId(this.quotaProjectId)
+                    .setAccessToken(new AccessToken("", new Date(0L)))
+                    .setRefreshHandler(() -> accessToken).build();
+        } else {
+            // Pipelines that only access to public data should be able to run without credentials.
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/google/cloud/solutions/autotokenize/auth/JupyterHubAccessTokenProvider.java
+++ b/src/main/java/com/google/cloud/solutions/autotokenize/auth/JupyterHubAccessTokenProvider.java
@@ -12,15 +12,14 @@ import java.util.logging.Logger;
 
 public class JupyterHubAccessTokenProvider implements OAuth2CredentialsWithRefresh.OAuth2RefreshHandler {
 
-    public static final String AUTH_PROVIDER_URL_KEY = "LOCAL_USER_PATH";
-    public static final String GCS_TOKEN_KEY = "GCS_TOKEN_PROVIDER_KEY";
     private final String gcsTokenKey;
     private static final Logger LOG = Logger.getLogger(JupyterHubAccessTokenProvider.class.getName());
 
-    private final AuthProviderClient client = new AuthProviderClient(System.getenv().get(AUTH_PROVIDER_URL_KEY));
+    private final AuthProviderClient client;
 
-    public JupyterHubAccessTokenProvider() {
-        this.gcsTokenKey = System.getenv().get(GCS_TOKEN_KEY);
+    public JupyterHubAccessTokenProvider(String authProviderURL, String gcsTokenKey) {
+        this.client = new AuthProviderClient(authProviderURL);
+        this.gcsTokenKey = gcsTokenKey;
         LOG.info(String.format("Ready to fetch '%s' tokens", this.gcsTokenKey));
     }
 

--- a/src/main/java/com/google/cloud/solutions/autotokenize/auth/JupyterHubAccessTokenProvider.java
+++ b/src/main/java/com/google/cloud/solutions/autotokenize/auth/JupyterHubAccessTokenProvider.java
@@ -1,0 +1,37 @@
+package com.google.cloud.solutions.autotokenize.auth;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.OAuth2CredentialsWithRefresh;
+import com.google.cloud.solutions.autotokenize.auth.client.AuthProviderClient;
+import com.google.cloud.solutions.autotokenize.auth.client.AuthResponse;
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.logging.Logger;
+
+public class JupyterHubAccessTokenProvider implements OAuth2CredentialsWithRefresh.OAuth2RefreshHandler {
+
+    public static final String AUTH_PROVIDER_URL_KEY = "LOCAL_USER_PATH";
+    public static final String GCS_TOKEN_KEY = "GCS_TOKEN_PROVIDER_KEY";
+    private final String gcsTokenKey;
+    private static final Logger LOG = Logger.getLogger(JupyterHubAccessTokenProvider.class.getName());
+
+    private final AuthProviderClient client = new AuthProviderClient(System.getenv().get(AUTH_PROVIDER_URL_KEY));
+
+    public JupyterHubAccessTokenProvider() {
+        this.gcsTokenKey = System.getenv().get(GCS_TOKEN_KEY);
+        LOG.info(String.format("Ready to fetch '%s' tokens", this.gcsTokenKey));
+    }
+
+    @Override
+    public AccessToken refreshAccessToken() throws IOException {
+        AuthResponse response = client.getAuth();
+        if (response.getExchangedTokens().isEmpty()) {
+            throw new IllegalStateException("Exchange tokens missing. Can not retrieve access tokens for GCS");
+        } else {
+            AuthResponse.ExchangedToken token = response.getExchangedTokens().get(this.gcsTokenKey);
+            return new AccessToken(token.getAccessToken(), new Date(token.getExpirationTimeMilliSeconds()));
+        }
+    }
+}

--- a/src/main/java/com/google/cloud/solutions/autotokenize/auth/OAuth2CredentialsWithRefreshAndQuotaProjectId.java
+++ b/src/main/java/com/google/cloud/solutions/autotokenize/auth/OAuth2CredentialsWithRefreshAndQuotaProjectId.java
@@ -1,0 +1,75 @@
+package com.google.cloud.solutions.autotokenize.auth;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.OAuth2Credentials;
+import com.google.auth.oauth2.OAuth2CredentialsWithRefresh;
+import com.google.auth.oauth2.QuotaProjectIdProvider;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class OAuth2CredentialsWithRefreshAndQuotaProjectId extends OAuth2CredentialsWithRefresh
+        implements QuotaProjectIdProvider {
+
+    private static final String QUOTA_PROJECT_ID_HEADER_KEY = "x-goog-user-project";
+
+    private final String quotaProjectId;
+    protected OAuth2CredentialsWithRefreshAndQuotaProjectId(AccessToken accessToken, OAuth2RefreshHandler refreshHandler,
+                                                         String quotaProjectId) {
+        super(accessToken, refreshHandler);
+        this.quotaProjectId = quotaProjectId;
+    }
+    @Override
+    public Map<String, List<String>> getRequestMetadata(URI uri) throws IOException {
+        Map<String, List<String>> newRequestMetadata = new HashMap<>(super.getRequestMetadata(uri));
+        if (quotaProjectId != null) {
+            newRequestMetadata.put(
+                    QUOTA_PROJECT_ID_HEADER_KEY, Collections.singletonList(quotaProjectId));
+        }
+        return Collections.unmodifiableMap(newRequestMetadata);
+    }
+
+    @Override
+    public String getQuotaProjectId() {
+        return quotaProjectId;
+    }
+
+    public static class Builder extends OAuth2Credentials.Builder {
+
+        private OAuth2RefreshHandler refreshHandler;
+        private String quotaProjectId;
+
+        public Builder() {
+            super();
+        }
+
+        /**
+         * Sets the {@link AccessToken} to be consumed. It must contain an expiration time otherwise an
+         * {@link IllegalArgumentException} will be thrown.
+         */
+        @Override
+        public OAuth2CredentialsWithRefreshAndQuotaProjectId.Builder setAccessToken(AccessToken token) {
+            super.setAccessToken(token);
+            return this;
+        }
+
+        /** Sets the {@link OAuth2RefreshHandler} to be used for token refreshes. */
+        public OAuth2CredentialsWithRefreshAndQuotaProjectId.Builder setRefreshHandler(OAuth2RefreshHandler handler) {
+            this.refreshHandler = handler;
+            return this;
+        }
+
+        public OAuth2CredentialsWithRefreshAndQuotaProjectId.Builder setQuotaProjectId(String quotaProjectId) {
+            this.quotaProjectId = quotaProjectId;
+            return this;
+        }
+
+        public OAuth2CredentialsWithRefreshAndQuotaProjectId build() {
+            return new OAuth2CredentialsWithRefreshAndQuotaProjectId(getAccessToken(), refreshHandler, quotaProjectId);
+        }
+    }
+}

--- a/src/main/java/com/google/cloud/solutions/autotokenize/auth/client/AuthProviderClient.java
+++ b/src/main/java/com/google/cloud/solutions/autotokenize/auth/client/AuthProviderClient.java
@@ -1,0 +1,86 @@
+package com.google.cloud.solutions.autotokenize.auth.client;
+
+import com.google.gson.Gson;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class AuthProviderClient {
+
+    private static final Logger LOG = Logger.getLogger(AuthProviderClient.class.getName());
+    private final String authProviderUrl;
+    private OkHttpClient client;
+
+    public AuthProviderClient(String authProviderUrl) {
+        this.authProviderUrl = authProviderUrl;
+        OkHttpClient.Builder builder = new OkHttpClient.Builder().callTimeout(20, TimeUnit.SECONDS);
+        builder.addInterceptor(new BearerTokenInterceptor(new JHubTokenSupplier()));
+        client = builder.build();
+        LOG.info(String.format("Using auth provider url: %s", this.authProviderUrl));
+    }
+
+    public AuthResponse getAuth() {
+        Request request = new Request.Builder()
+                .url(this.authProviderUrl).get().build();
+
+        try (Response response = client.newCall(request).execute()) {
+            String json = getJson(response);
+            handleErrorCodes(response, json);
+            Gson gson = new Gson();
+            return gson.fromJson(json, AuthResponse.class);
+        } catch (IOException e) {
+            LOG.log(Level.WARNING, "getAccessToken failed", e);
+            throw new AuthProviderException(e);
+        }
+    }
+
+    private String getJson(Response response) throws IOException {
+        ResponseBody body = response.body();
+        if (body == null) return null;
+        return body.string();
+    }
+
+    private void handleErrorCodes(Response response, String body) {
+        if (response.code() == HttpURLConnection.HTTP_UNAUTHORIZED || response.code() == HttpURLConnection.HTTP_FORBIDDEN) {
+            throw new AuthProviderException("Access denied", body);
+        } else if (response.code() == HttpURLConnection.HTTP_NOT_FOUND) {
+            throw new AuthProviderException("Invalid URL: " + this.authProviderUrl);
+        } else if (response.code() < 200 || response.code() >= 400) {
+            throw new AuthProviderException("Unknown error: " + response, body);
+        }
+    }
+
+    public static class AuthProviderException extends RuntimeException {
+        private final String body;
+
+        public AuthProviderException(Throwable cause) {
+            super(cause);
+            this.body = null;
+        }
+
+        public AuthProviderException(String message) {
+            this(message, null);
+        }
+
+        public AuthProviderException(String message, String body) {
+            super(message);
+            this.body = body;
+        }
+
+        @Override
+        public String getMessage() {
+            if (body == null) {
+                return super.getMessage();
+            }
+            return super.getMessage() + "\n" + body;
+        }
+    }
+
+}

--- a/src/main/java/com/google/cloud/solutions/autotokenize/auth/client/AuthResponse.java
+++ b/src/main/java/com/google/cloud/solutions/autotokenize/auth/client/AuthResponse.java
@@ -1,0 +1,49 @@
+package com.google.cloud.solutions.autotokenize.auth.client;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Map;
+
+public class AuthResponse {
+
+    @SerializedName("access_token")
+    private String accessToken;
+    @SerializedName("exchanged_tokens")
+    private Map<String, ExchangedToken> exchangedTokens;
+
+    public AuthResponse(String accessToken, Map<String, ExchangedToken> exchangedTokens) {
+        this.accessToken = accessToken;
+        this.exchangedTokens = exchangedTokens;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public Map<String, ExchangedToken> getExchangedTokens() {
+        return exchangedTokens;
+    }
+
+    public class ExchangedToken {
+        @SerializedName("access_token")
+        private String accessToken;
+        private int exp;
+
+        public ExchangedToken(String accessToken, int exp) {
+            this.accessToken = accessToken;
+            this.exp = exp;
+        }
+
+        public String getAccessToken() {
+            return accessToken;
+        }
+
+        public int getExp() {
+            return exp;
+        }
+
+        public Long getExpirationTimeMilliSeconds() {
+            return System.currentTimeMillis() + (exp * 1000);
+        }
+    }
+}

--- a/src/main/java/com/google/cloud/solutions/autotokenize/auth/client/BearerTokenInterceptor.java
+++ b/src/main/java/com/google/cloud/solutions/autotokenize/auth/client/BearerTokenInterceptor.java
@@ -1,0 +1,34 @@
+package com.google.cloud.solutions.autotokenize.auth.client;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * Interceptor that adds a <p>Bearer</p> token to a request.
+ */
+public class BearerTokenInterceptor implements Interceptor {
+
+    private static final String AUTHORIZATION_HEADER_NAME = "Authorization";
+    private final Supplier<String> tokenSupplier;
+
+    /**
+     * Create new instance
+     *
+     * @param tokenSupplier the token supplier
+     */
+    public BearerTokenInterceptor(Supplier<String> tokenSupplier) {
+        this.tokenSupplier = Objects.requireNonNull(tokenSupplier);
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Request.Builder newRequest = chain.request().newBuilder();
+        newRequest.header(AUTHORIZATION_HEADER_NAME, String.format("Bearer %s", tokenSupplier.get()));
+        return chain.proceed(newRequest.build());
+    }
+}

--- a/src/main/java/com/google/cloud/solutions/autotokenize/auth/client/JHubTokenSupplier.java
+++ b/src/main/java/com/google/cloud/solutions/autotokenize/auth/client/JHubTokenSupplier.java
@@ -1,0 +1,13 @@
+package com.google.cloud.solutions.autotokenize.auth.client;
+
+import java.util.function.Supplier;
+
+public class JHubTokenSupplier implements Supplier<String> {
+
+    private static final String JHUB_API_KEY = "JUPYTERHUB_API_TOKEN";
+
+    @Override
+    public String get() {
+        return System.getenv(JHUB_API_KEY);
+    }
+}

--- a/src/main/java/com/google/cloud/solutions/autotokenize/dlp/DlpClientFactory.java
+++ b/src/main/java/com/google/cloud/solutions/autotokenize/dlp/DlpClientFactory.java
@@ -36,7 +36,7 @@ public interface DlpClientFactory extends Serializable {
 
     @Override
     public DlpServiceClient newClient() throws IOException {
-      return DlpServiceClient.create(DlpServiceSettings.newBuilder().setQuotaProjectId("dev-sirius").build());
+      return DlpServiceClient.create(DlpServiceSettings.newBuilder().build());
     }
   }
 }

--- a/src/main/java/com/google/cloud/solutions/autotokenize/dlp/DlpClientFactory.java
+++ b/src/main/java/com/google/cloud/solutions/autotokenize/dlp/DlpClientFactory.java
@@ -18,6 +18,8 @@ package com.google.cloud.solutions.autotokenize.dlp;
 
 
 import com.google.cloud.dlp.v2.DlpServiceClient;
+import com.google.cloud.dlp.v2.DlpServiceSettings;
+
 import java.io.IOException;
 import java.io.Serializable;
 
@@ -34,7 +36,7 @@ public interface DlpClientFactory extends Serializable {
 
     @Override
     public DlpServiceClient newClient() throws IOException {
-      return DlpServiceClient.create();
+      return DlpServiceClient.create(DlpServiceSettings.newBuilder().setQuotaProjectId("dev-sirius").build());
     }
   }
 }

--- a/src/main/java/com/google/cloud/solutions/autotokenize/pipeline/AutoInspectAndTokenizeOptions.java
+++ b/src/main/java/com/google/cloud/solutions/autotokenize/pipeline/AutoInspectAndTokenizeOptions.java
@@ -19,12 +19,11 @@ package com.google.cloud.solutions.autotokenize.pipeline;
 
 import com.google.cloud.solutions.autotokenize.AutoTokenizeMessages;
 import java.util.List;
-import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Validation.Required;
 
 /** Common options for Inspection and Tokenization pipelines. */
-public interface AutoInspectAndTokenizeOptions extends GcpOptions {
+public interface AutoInspectAndTokenizeOptions extends UserEnvironmentOptions {
   @Required
   AutoTokenizeMessages.SourceType getSourceType();
 
@@ -89,4 +88,5 @@ public interface AutoInspectAndTokenizeOptions extends GcpOptions {
   String getJdbcPassword();
 
   void setJdbcPassword(String jdbcPassword);
+
 }

--- a/src/main/java/com/google/cloud/solutions/autotokenize/pipeline/DlpInspectionPipeline.java
+++ b/src/main/java/com/google/cloud/solutions/autotokenize/pipeline/DlpInspectionPipeline.java
@@ -16,20 +16,13 @@
 
 package com.google.cloud.solutions.autotokenize.pipeline;
 
-import static com.google.cloud.solutions.autotokenize.auth.JupyterHubAccessTokenProvider.*;
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static org.apache.beam.sdk.io.FileIO.Write.defaultNaming;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-
 import com.google.auth.oauth2.AccessToken;
-import com.google.auth.oauth2.OAuth2CredentialsWithRefresh;
 import com.google.cloud.dlp.v2.DlpServiceClient;
 import com.google.cloud.solutions.autotokenize.AutoTokenizeMessages.ColumnInformation;
 import com.google.cloud.solutions.autotokenize.AutoTokenizeMessages.FlatRecord;
 import com.google.cloud.solutions.autotokenize.AutoTokenizeMessages.InspectionReport;
 import com.google.cloud.solutions.autotokenize.auth.JupyterHubAccessTokenProvider;
+import com.google.cloud.solutions.autotokenize.auth.OAuth2CredentialsWithRefreshAndQuotaProjectId;
 import com.google.cloud.solutions.autotokenize.common.InspectionReportFileWriter;
 import com.google.cloud.solutions.autotokenize.common.InspectionReportToTableRow;
 import com.google.cloud.solutions.autotokenize.common.SecretsClient;
@@ -48,9 +41,6 @@ import com.google.privacy.dlp.v2.InfoType;
 import com.google.privacy.dlp.v2.Table;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
-import java.time.Clock;
-import java.util.Date;
-
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
@@ -70,6 +60,15 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.TupleTag;
+
+import java.time.Clock;
+import java.util.Date;
+
+import static com.google.cloud.solutions.autotokenize.auth.JupyterHubAccessTokenProvider.*;
+import static com.google.common.base.Preconditions.*;
+import static com.google.common.collect.ImmutableSet.*;
+import static org.apache.beam.sdk.io.FileIO.Write.*;
+import static org.apache.commons.lang3.StringUtils.*;
 
 /** Instantiates the sampling Dataflow pipeline based on provided options. */
 public final class DlpInspectionPipeline {
@@ -302,15 +301,17 @@ public final class DlpInspectionPipeline {
     logger.atInfo().log("Staging the Dataflow job");
     if (System.getenv().containsKey(AUTH_PROVIDER_URL_KEY)) {
       logger.atInfo().log("Using credential provider url");
-      options.setGcpCredential(OAuth2CredentialsWithRefresh.newBuilder()
+      options.setGcpCredential(new OAuth2CredentialsWithRefreshAndQuotaProjectId.Builder()
+              .setQuotaProjectId(options.getProject())
               .setAccessToken(new AccessToken("", new Date(0L)))
               .setRefreshHandler(new JupyterHubAccessTokenProvider()).build());
     } else if (System.getenv().containsKey("GCS_TOKEN")) {
       logger.atInfo().log("Using credentials from env variable");
       AccessToken accessToken = new AccessToken(System.getenv().get("GCS_TOKEN"), new Date(System.currentTimeMillis()
               + 3600 * 1000));
-      options.setGcpCredential(OAuth2CredentialsWithRefresh.newBuilder()
-              .setAccessToken(accessToken)
+      options.setGcpCredential(new OAuth2CredentialsWithRefreshAndQuotaProjectId.Builder()
+              .setQuotaProjectId(options.getProject())
+              .setAccessToken(new AccessToken("", new Date(0L)))
               .setRefreshHandler(() -> accessToken).build());
     }
     new DlpInspectionPipeline(options).makePipeline().run();

--- a/src/main/java/com/google/cloud/solutions/autotokenize/pipeline/UserEnvironmentOptions.java
+++ b/src/main/java/com/google/cloud/solutions/autotokenize/pipeline/UserEnvironmentOptions.java
@@ -31,7 +31,7 @@ import org.joda.time.format.DateTimeFormatter;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * Common options for Jupyter notebook aware pipelines.
+ * Additional user specific options.
  */
 public interface UserEnvironmentOptions extends GcpOptions {
 
@@ -65,13 +65,13 @@ public interface UserEnvironmentOptions extends GcpOptions {
 
         @Override
         public String create(PipelineOptions options) {
-            UserEnvironmentOptions jupyterGcpOptions = options.as(UserEnvironmentOptions.class);
+            UserEnvironmentOptions userEnvironmentOptions = options.as(UserEnvironmentOptions.class);
             String appName = options.as(ApplicationNameOptions.class).getAppName();
             String normalizedAppName =
                     appName == null || appName.length() == 0
                             ? "BeamApp"
                             : appName.toLowerCase().replaceAll("[^a-z0-9]", "0").replaceAll("^[^a-z]", "a");
-            String userName = jupyterGcpOptions.getUserName();
+            String userName = userEnvironmentOptions.getUserName();
             String normalizedUserName = userName.toLowerCase().replaceAll("[^a-z0-9]", "0");
             String datePart = FORMATTER.print(DateTimeUtils.currentTimeMillis());
 

--- a/src/main/java/com/google/cloud/solutions/autotokenize/pipeline/UserEnvironmentOptions.java
+++ b/src/main/java/com/google/cloud/solutions/autotokenize/pipeline/UserEnvironmentOptions.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.solutions.autotokenize.pipeline;
+
+
+import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
+import org.apache.beam.sdk.options.ApplicationNameOptions;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.DefaultValueFactory;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
+import org.joda.time.DateTimeUtils;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Common options for Jupyter notebook aware pipelines.
+ */
+public interface UserEnvironmentOptions extends GcpOptions {
+
+    @Default.InstanceFactory(UserNameFactory.class)
+    String getUserName();
+
+    void setUserName(String userName);
+
+    /**
+     * Factory for generating username by looking up the 'user.name' system property.
+     */
+    class UserNameFactory implements DefaultValueFactory<String> {
+        @Override
+        public String create(PipelineOptions options) {
+            return MoreObjects.firstNonNull(System.getProperty("user.name"), "");
+        }
+    }
+    /**
+     * Returns a normalized job name constructed from {@link ApplicationNameOptions#getAppName()},
+     * {@link UserEnvironmentOptions#getUserName()}, the current time, and a random integer.
+     * <p>
+     * This implementation is almost identical as {@link org.apache.beam.sdk.options.PipelineOptions.JobNameFactory},
+     * except that the username can be set from the pipeline options.
+     *
+     * <p>The normalization makes sure that the name matches the pattern of
+     * [a-z]([-a-z0-9]*[a-z0-9])?.
+     */
+    class JobNameFactory implements DefaultValueFactory<String> {
+        private static final DateTimeFormatter FORMATTER =
+                DateTimeFormat.forPattern("MMddHHmmss").withZone(DateTimeZone.UTC);
+
+        @Override
+        public String create(PipelineOptions options) {
+            UserEnvironmentOptions jupyterGcpOptions = options.as(UserEnvironmentOptions.class);
+            String appName = options.as(ApplicationNameOptions.class).getAppName();
+            String normalizedAppName =
+                    appName == null || appName.length() == 0
+                            ? "BeamApp"
+                            : appName.toLowerCase().replaceAll("[^a-z0-9]", "0").replaceAll("^[^a-z]", "a");
+            String userName = jupyterGcpOptions.getUserName();
+            String normalizedUserName = userName.toLowerCase().replaceAll("[^a-z0-9]", "0");
+            String datePart = FORMATTER.print(DateTimeUtils.currentTimeMillis());
+
+            String randomPart = Integer.toHexString(ThreadLocalRandom.current().nextInt());
+            return String.format(
+                    "%s-%s-%s-%s", normalizedAppName, normalizedUserName, datePart, randomPart);
+        }
+    }    
+}


### PR DESCRIPTION
It is now possible to supply access tokens to authenticate against Google Cloud Platform services. This can be done either by setting the `GCS_TOKEN` environment variable or by using the Jupyter specific `LOCAL_USER_PATH`.

Added an additional pipeline option `--userName` to manually set the user name which will be supplied to the pipeline's JobNameFactory.