### PR TITLE
Improved handling of options from Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,9 +365,9 @@ And then execute the sample & identify pipeline through Python
 
 ```Python
 import os
-from dapla_dlp import PipelineOptions, start_dlp_inspection_pipeline
+from dapla_dlp import InspectionOptions, start_dlp_inspection_pipeline
 
-options = PipelineOptions(
+options = InspectionOptions(
     projectId = os.environ['PROJECT_ID'],
     regionId = os.environ['REGION_ID'],
     serviceAccount = os.environ['DLP_RUNNER_SERVICE_ACCOUNT_EMAIL'],

--- a/src/main/python/dapla_dlp/__init__.py
+++ b/src/main/python/dapla_dlp/__init__.py
@@ -1,3 +1,3 @@
 __version__ = "0.0.1"
 
-from .dlp import PipelineOptions, start_dlp_inspection_pipeline, start_tokenize_pipeline
+from .dlp import InspectionOptions, TokenizeOptions, start_dlp_inspection_pipeline, start_tokenize_pipeline

--- a/src/main/python/dapla_dlp/dlp.py
+++ b/src/main/python/dapla_dlp/dlp.py
@@ -1,54 +1,114 @@
+from subprocess import Popen, PIPE, STDOUT
+import os
 
-class PipelineOptions:
+
+class _DefaultOptions:
+    """ Base class for classes that need to use options """
+    # All options with default values. If a value is None, it needs to be overridden
+    projectId = None
+    regionId = 'europe-north1'
+    serviceAccountPrefix = 'dlpflow-runner'
+    tempGcsBucket = None
+    workerMachineType = 'n1-standard-1'
+    subnetworkName = 'dataflow-subnetwork'
+    sampleSize = 100
+    sourceType = 'PARQUET'
+    inputPattern = None
+    logFile = STDOUT
+    userName = os.environ['JUPYTERHUB_USER']
+
+    class OptionError(AttributeError): pass
+
     def __init__(self, **kw):
         self.__dict__.update(kw)
 
+    def validate(self):
+        for att in dir(self):
+            if not att.startswith('_') and getattr(self, att) is None:
+                raise self.OptionError("missing required option: " + att)
 
-def start_dlp_inspection_pipeline(options):
+    def init_options(self, option, kw):
+        """ To be called from the derived class constructor.
+        Puts the options into object scope. """
+        for k, v in list(option.__dict__.items()) + list(kw.items()):
+            if not hasattr(self.__class__, k):
+                raise self.OptionError("invalid option: " + k)
+            setattr(self, k, v)
 
+
+class InspectionOptions(_DefaultOptions):
+
+    # Extra options
+    reportLocation = None
+
+    def __init__(self, opt=_DefaultOptions(), **kw):
+        """ instance-constructor """
+        self.init_options(opt, kw)
+
+
+class TokenizeOptions(_DefaultOptions):
+
+    # Extra options
+    kmsKeyringId = 'dlpflow-keyring'
+    kmsKeyId = 'dlpflow-key-encryption-key-1'
+    secretManagerKeyName = 'dlpflow-tinkey-wrapped-key-1'
+    schemaLocation = None
+    tokenizeColumns = None
+    outputDirectory = None
+
+    def __init__(self, opt=_DefaultOptions(), **kw):
+        """ instance-constructor """
+        self.init_options(opt, kw)
+
+
+def start_dlp_inspection_pipeline(options: InspectionOptions):
+
+    options.validate()
     options_str = f'--project={options.projectId} \
     --region={options.regionId} \
+    --userName={options.userName} \
     --runner=DataflowRunner \
-    --serviceAccount={options.serviceAccount} \
+    --serviceAccount={options.serviceAccountPrefix}@{options.projectId}.iam.gserviceaccount.com \
     --gcpTempLocation=gs://{options.tempGcsBucket}/temp \
     --stagingLocation=gs://{options.tempGcsBucket}/staging \
     --tempLocation=gs://{options.tempGcsBucket}/bqtemp \
-    --workerMachineType=n1-standard-1 \
+    --workerMachineType={options.workerMachineType} \
     --subnetwork=https://www.googleapis.com/compute/v1/projects/{options.projectId}/regions/{options.regionId}/subnetworks/{options.subnetworkName} \
-    --sampleSize=600 \
-    --sourceType=PARQUET \
+    --sampleSize={options.sampleSize} \
+    --sourceType={options.sourceType} \
     --inputPattern={options.inputPattern} \
     --reportLocation={options.reportLocation}'
 
-    _run_pipeline('com.google.cloud.solutions.autotokenize.pipeline.DlpInspectionPipeline', options_str.split(' '))
+    _run_pipeline('com.google.cloud.solutions.autotokenize.pipeline.DlpInspectionPipeline', options_str.split(' '),
+                  stderr=STDOUT if options.logFile is STDOUT else open(options.logFile, mode='w'))
 
 
-def start_tokenize_pipeline(options):
+def start_tokenize_pipeline(options: TokenizeOptions):
+
+    options.validate()
     options_str = f'--project={options.projectId} \
     --region={options.regionId} \
+    --userName={options.userName} \
     --runner=DataflowRunner \
-    --serviceAccount={options.serviceAccount} \
+    --serviceAccount={options.serviceAccountPrefix}@{options.projectId}.iam.gserviceaccount.com \
     --tempLocation=gs://{options.tempGcsBucket}/bqtemp \
-    --workerMachineType=n1-standard-1 \
-    --schema={options.schema} \
+    --workerMachineType={options.workerMachineType} \
+    --schemaLocation={options.schemaLocation} \
     --mainKmsKeyUri=gcp-kms://projects/{options.projectId}/locations/{options.regionId}/keyRings/{options.kmsKeyringId}/cryptoKeys/{options.kmsKeyId} \
     --keyMaterialType=TINK_GCP_KEYSET_JSON_FROM_SECRET_MANAGER \
-    --keyMaterial=projects/{options.projectNumber}/secrets/{options.secretManagerKeyName}/versions/latest \
+    --keyMaterial=projects/{options.projectId}/secrets/{options.secretManagerKeyName}/versions/latest \
     --subnetwork=https://www.googleapis.com/compute/v1/projects/{options.projectId}/regions/{options.regionId}/subnetworks/{options.subnetworkName} \
-    --sourceType=PARQUET \
+    --sourceType={options.sourceType} \
     --inputPattern={options.inputPattern} \
     --outputDirectory={options.outputDirectory} \
-    {" ".join(map(lambda col: "--tokenizeColumns=" + col, options.tokenize_columns))}'
+    {" ".join(map(lambda col: "--tokenizeColumns=" + col, options.tokenizeColumns))}'
 
-    _run_pipeline('com.google.cloud.solutions.autotokenize.pipeline.EncryptionPipeline', options_str.split(' '))
+    _run_pipeline('com.google.cloud.solutions.autotokenize.pipeline.EncryptionPipeline', options_str.split(' '),
+                  stderr=STDOUT if options.logFile is STDOUT else open(options.logFile, mode='w'))
 
 
-
-
-def _run_pipeline(pipeline_name, options):
-    from subprocess import Popen, PIPE, STDOUT
-    import os
-    p = Popen(['java', '-cp', os.environ['AUTO_TOKENIZE_JAR'], pipeline_name] + options, stdout=PIPE, stderr=STDOUT)
+def _run_pipeline(pipeline_name, options, stdout=PIPE, stderr=STDOUT):
+    p = Popen(['java', '-cp', os.environ['AUTO_TOKENIZE_JAR'], pipeline_name] + options, stdout=stdout, stderr=stderr)
 
     while True:
         # Wait for some output, read it and print it.


### PR DESCRIPTION
Introduced separate options for DLP inspection and tokenization. Improved validation of required oprions, and introduced sensible "default" options. A minimal configuration can now look like this:

```
from dapla_dlp import InspectionOptions

options = InspectionOptions(
    projectId = 'staging-demo-enhjoern-a-6a2d',
    tempGcsBucket = 'ssb-staging-demo-enhjoern-a-dlp',
    inputPattern = 'gs://ssb-staging-demo-enhjoern-a-data-kilde/dlpflow-test/person_1200.parquet',
    reportLocation = 'gs://ssb-staging-demo-enhjoern-a-dlp/dlpreport/01-jupyter'
)
```